### PR TITLE
Fix nested expander in kb builder

### DIFF
--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -1580,9 +1580,15 @@ with tab3:
                                             
                                             # デバッグ情報
                                             if show_debug:
-                                                with st.expander("⚙ デバッグ: チャンクとファイルパス"):
+                                                with st.popover("⚙ デバッグ: チャンクとファイルパス"):
                                                     st.markdown("**検索チャンク:**")
-                                                    st.text_area("", chunk_data.get('content', ''), height=100, disabled=True, key=f"debug_chunk_{i}")
+                                                    st.text_area(
+                                                        "",
+                                                        chunk_data.get('content', ''),
+                                                        height=100,
+                                                        disabled=True,
+                                                        key=f"debug_chunk_{i}"
+                                                    )
                                                     st.markdown("**ファイルパス:**")
                                                     st.write(f"chunks: {chunks_dir / f'{item_id}.json'}")
                                                     st.write(f"embeddings: {embeddings_dir / f'{item_id}.json'}")


### PR DESCRIPTION
## Summary
- replace debug expander with `st.popover` so expanders are not nested
- drop unrelated changes to the legacy `旧app.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea9fbdee08333abacfd1fe1614f50