### PR TITLE
Add tests for KnowledgeBuilder and search engine

### DIFF
--- a/tests/test_kb_builder.py
+++ b/tests/test_kb_builder.py
@@ -1,0 +1,32 @@
+import pytest
+pytest.importorskip("PyPDF2")
+
+from io import BytesIO
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from shared import upload_utils
+from shared.kb_builder import KnowledgeBuilder
+
+
+def test_build_from_file_creates_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+
+    builder = KnowledgeBuilder()
+    builder.get_openai_client = lambda: object()
+    builder.get_embedding = lambda text, client=None: [0.1]
+    builder.refresh_search_engine = lambda name: None
+
+    buf = BytesIO(b"hello world")
+    buf.name = "sample.txt"
+
+    result = builder.build_from_file(buf)
+    assert result is not None
+
+    chunk_path = Path(result["chunk_path"])
+    emb_path = Path(result["embedding_path"])
+    meta_path = Path(result["metadata_path"])
+    assert chunk_path.exists()
+    assert emb_path.exists()
+    assert meta_path.exists()

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -1,0 +1,28 @@
+import pytest
+pytest.importorskip("numpy")
+
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from knowledge_gpt_app import knowledge_search
+
+
+def test_hybrid_search_output_format(monkeypatch):
+    engine = knowledge_search.HybridSearchEngine.__new__(knowledge_search.HybridSearchEngine)
+    engine.chunks = [{"id": "c1", "text": "hello world", "metadata": {}}]
+    engine.embeddings = {"c1": [1.0]}
+    engine.bm25_index = SimpleNamespace(get_scores=lambda tokens: [1.0])
+    engine.tokenized_corpus_for_bm25 = [["hello"]]
+    engine.model = None
+    engine.embedding_model = "dummy"
+
+    monkeypatch.setattr(engine, "get_embedding_from_openai", lambda q, client=None: [1.0])
+    monkeypatch.setattr(knowledge_search, "tokenize_text_for_bm25_internal", lambda q: ["hello"])
+
+    results, not_found = engine.search("hello", top_k=1, threshold=0.0, vector_weight=1.0, bm25_weight=1.0)
+    assert not not_found
+    assert isinstance(results, list) and results
+    first = results[0]
+    assert {"id", "text", "metadata", "similarity", "vector_score", "bm25_score"} <= first.keys()


### PR DESCRIPTION
## Summary
- add a unit test verifying `KnowledgeBuilder.build_from_file`
- add a unit test for the search engine hybrid search output format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eafbefed483338d4f6ea6d75de9d5