### PR TITLE
Implement thumbnail metadata editor

### DIFF
--- a/shared/upload_utils.py
+++ b/shared/upload_utils.py
@@ -95,3 +95,13 @@ def save_processed_data(
         paths["metadata_path"] = str(meta_path)
 
     return paths
+
+
+def save_user_metadata(kb_name: str, item_id: str, title: str, tags: list[str]) -> str:
+    """Store user-provided metadata for an item and return the file path."""
+    kb_dir = BASE_KNOWLEDGE_DIR / kb_name / "metadata"
+    kb_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = kb_dir / f"{item_id}_user.json"
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump({"title": title, "tags": tags}, f, ensure_ascii=False, indent=2)
+    return str(meta_path)

--- a/ui_modules/thumbnail_editor.py
+++ b/ui_modules/thumbnail_editor.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+import streamlit as st
+
+from shared.upload_utils import BASE_KNOWLEDGE_DIR, save_user_metadata
+
+
+def _load_items(kb_name: str) -> List[Dict[str, Any]]:
+    """Load stored items for the given knowledge base."""
+    items = []
+    meta_dir = BASE_KNOWLEDGE_DIR / kb_name / "metadata"
+    if not meta_dir.exists():
+        return items
+    for meta_path in meta_dir.glob("metadata_*.json"):
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+        except Exception:
+            continue
+        item_id = meta_path.stem.split("metadata_")[-1]
+        text = ""
+        chunk_path = meta.get("paths", {}).get("chunk_path")
+        if chunk_path and Path(chunk_path).exists():
+            try:
+                txt = Path(chunk_path).read_text(encoding="utf-8")
+                mid = len(txt) // 2
+                snippet = txt[max(0, mid - 6) : mid + 6]
+                text = snippet.strip()
+            except Exception:
+                pass
+        items.append({"id": item_id, "meta": meta, "snippet": text})
+    return items
+
+
+def display_thumbnail_grid(kb_name: str) -> None:
+    """Render a 3x3 thumbnail grid for items in the knowledge base."""
+    items = _load_items(kb_name)
+    if not items:
+        st.info("No uploaded items found.")
+        return
+
+    per_page = 9
+    page_key = f"thumb_page_{kb_name}"
+    if page_key not in st.session_state:
+        st.session_state[page_key] = 0
+    page = st.session_state[page_key]
+    total_pages = (len(items) - 1) // per_page + 1
+    start = page * per_page
+    end = start + per_page
+    st.markdown(f"**Page {page+1}/{total_pages}**")
+    nav_prev, nav_next = st.columns(2)
+    with nav_prev:
+        if st.button("Prev", disabled=page == 0, key=f"prev_{kb_name}"):
+            st.session_state[page_key] = max(page - 1, 0)
+            st.experimental_rerun()
+    with nav_next:
+        if st.button("Next", disabled=page >= total_pages - 1, key=f"next_{kb_name}"):
+            st.session_state[page_key] = min(page + 1, total_pages - 1)
+            st.experimental_rerun()
+
+    grid_items = items[start:end]
+    rows = [grid_items[i : i + 3] for i in range(0, len(grid_items), 3)]
+    for row in rows:
+        cols = st.columns(3)
+        for col, item in zip(cols, row):
+            with col:
+                st.button(item.get("snippet", "(no text)"), key=f"sel_{item['id']}", on_click=lambda iid=item['id']: st.session_state.update({"current_editing_id": iid}))
+
+    edit_id = st.session_state.get("current_editing_id")
+    if edit_id:
+        target = next((it for it in items if it["id"] == edit_id), None)
+        if target:
+            st.markdown("---")
+            st.subheader(f"Edit metadata for {edit_id}")
+            title = st.text_input("Title", value=target["meta"].get("title", ""))
+            tags = st.text_input("Tags (comma separated)", value=",".join(target["meta"].get("tags", [])))
+            if st.button("Save", key=f"save_{edit_id}"):
+                save_user_metadata(kb_name, edit_id, title, [t.strip() for t in tags.split(",") if t.strip()])
+                st.success("Saved metadata")
+                st.session_state.current_editing_id = None
+                st.experimental_rerun()

--- a/unified_app.py
+++ b/unified_app.py
@@ -8,6 +8,7 @@ from knowledge_gpt_app.app import (
     get_openai_client,
 )
 from knowledge_gpt_app.gpt_handler import generate_gpt_response
+from ui_modules.thumbnail_editor import display_thumbnail_grid
 
 # Global page config and styling
 st.set_page_config(layout="wide", page_title="KNOWLEDGE+")
@@ -144,3 +145,6 @@ with st.expander("ナレッジを追加する"):
                     )
                     refresh_search_engine("default_kb")
         st.toast("アップロード完了")
+
+st.divider()
+display_thumbnail_grid("default_kb")


### PR DESCRIPTION
## Summary
- add new user metadata saving util
- implement thumbnail editor UI module
- show uploaded items with editable metadata in unified app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebbed017883339f7d725e5161d497