### PR TITLE
Add batch processing and manual index refresh

### DIFF
--- a/tests/test_unified_app.py
+++ b/tests/test_unified_app.py
@@ -6,5 +6,16 @@ def test_sidebar_has_faq_button():
     text = Path('unified_app.py').read_text(encoding='utf-8')
     assert 'FAQ生成' in text
     assert '処理モード' in text
+    assert '個別処理' in text
+    assert 'まとめて処理' in text
     assert 'インデックス更新' in text
+    assert '自動(処理後)' in text
+    assert '手動' in text
     assert '検索インデックス更新' in text
+
+
+def test_manual_refresh_call_present():
+    text = Path('unified_app.py').read_text(encoding='utf-8')
+    import re
+    pattern = r'if st\.button\("検索インデックス更新"\).*refresh_search_engine\("default_kb"\)'
+    assert re.search(pattern, text, re.DOTALL)


### PR DESCRIPTION
## Summary
- update `unified_app.py` upload UI with processing and index options
- allow batch uploads with single refresh
- show manual refresh button when selected
- test for new controls and manual refresh code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2f75ac708333b40de4334e3f9d39