### PR TITLE
Fix theme function calls

### DIFF
--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -284,7 +284,7 @@ if "_page_configured" not in st.session_state:
     st.session_state["_page_configured"] = True
 
 # カスタムCSSを適用
-apply_intel_theme()
+apply_intel_theme(st)
 
 st.title("RAGシステム統合ツール")
 

--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -45,7 +45,7 @@ if not st.session_state.get("_page_configured", False):
     st.session_state["_page_configured"] = True
 
 # インテル風テーマ適用
-apply_intel_theme()
+apply_intel_theme(st)
 
 # ライブラリチェック
 try:

--- a/tests/test_theme_call.py
+++ b/tests/test_theme_call.py
@@ -1,0 +1,20 @@
+import ast
+from pathlib import Path
+
+
+def _get_theme_call_args(path: str) -> int | None:
+    tree = ast.parse(Path(path).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == 'apply_intel_theme':
+                return len(node.args)
+    return None
+
+
+def test_mm_kb_theme_call_uses_arg():
+    assert _get_theme_call_args('mm_kb_builder/app.py') == 1
+
+
+def test_gpt_app_theme_call_uses_arg():
+    assert _get_theme_call_args('knowledge_gpt_app/app.py') == 1


### PR DESCRIPTION
## Summary
- pass streamlit to `apply_intel_theme` in both apps
- add tests verifying the theme call includes the required argument

## Testing
- `pytest -q`
- `python mm_kb_builder/app.py` *(fails: ModuleNotFoundError: No module named 'streamlit')*
- `python knowledge_gpt_app/app.py` *(fails: ModuleNotFoundError: No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_685f3ac2191483338c0d06d892766367