### PR TITLE
Centralize default KB name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ export OPENAI_API_KEY=your_api_key_here
 set OPENAI_API_KEY=your_api_key_here
 ```
 
+### Default Knowledge Base
+
+Uploads and generated embeddings are stored under `knowledge_base/<kb_name>`.
+The default name is controlled by `DEFAULT_KB_NAME` in `config.py` and is set to
+`"default_kb"`. Change this constant if you want to use a different directory.
+
 ### Font Requirement
 
 `knowledge_gpt_app/utils/export.py` needs the IPAexGothic font (`ipaexg.ttf`) to export PDFs. Download the font from [https://moji.or.jp/ipafont/](https://moji.or.jp/ipafont/) and place `ipaexg.ttf` in the repository root.

--- a/config.py
+++ b/config.py
@@ -1,2 +1,6 @@
 EMBEDDING_MODEL = "text-embedding-3-large"
 EMBEDDING_DIMENSIONS = 3072
+
+# Default location for saved chunks, embeddings and other assets
+# from both the chatbot and the multimodal builder.
+DEFAULT_KB_NAME = "default_kb"

--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -2,7 +2,7 @@ import os
 import sys
 import streamlit as st
 from openai import OpenAI
-from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS
+from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS, DEFAULT_KB_NAME
 import PyPDF2
 import docx
 import pandas as pd
@@ -244,7 +244,7 @@ if 'processed_chunks' not in st.session_state:
 if 'detected_doc_type' not in st.session_state:
     st.session_state['detected_doc_type'] = None
 if 'knowledge_base_name' not in st.session_state:
-    st.session_state['knowledge_base_name'] = "default_kb"
+    st.session_state['knowledge_base_name'] = DEFAULT_KB_NAME
 if 'max_chunk_size' not in st.session_state:
     st.session_state['max_chunk_size'] = 1000
 if 'forced_overlap_ratio' not in st.session_state:

--- a/knowledge_gpt_app/app2.py
+++ b/knowledge_gpt_app/app2.py
@@ -1,7 +1,7 @@
 import os
 import streamlit as st
 from openai import OpenAI
-from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS
+from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS, DEFAULT_KB_NAME
 import PyPDF2
 import docx
 import pandas as pd
@@ -201,7 +201,7 @@ if 'processed_chunks' not in st.session_state:
 if 'detected_doc_type' not in st.session_state:
     st.session_state['detected_doc_type'] = None
 if 'knowledge_base_name' not in st.session_state:
-    st.session_state['knowledge_base_name'] = "default_kb"
+    st.session_state['knowledge_base_name'] = DEFAULT_KB_NAME
 if 'max_chunk_size' not in st.session_state:
     st.session_state['max_chunk_size'] = 1000
 if 'forced_overlap_ratio' not in st.session_state:

--- a/knowledge_gpt_app/knowledge_search.py
+++ b/knowledge_gpt_app/knowledge_search.py
@@ -1,6 +1,6 @@
 import os
 import json
-from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS
+from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS, DEFAULT_KB_NAME
 import numpy as np
 # from sklearn.feature_extraction.text import TfidfVectorizer # BM25には不要
 from sklearn.metrics.pairwise import cosine_similarity
@@ -547,7 +547,7 @@ def get_openai_client_for_kb_search():
 if __name__ == "__main__":
     print("knowledge_search.py を直接実行します (テストモード)")
     script_dir = Path(__file__).resolve().parent
-    default_test_kb_relative_path = "../knowledge_base/default_kb"
+    default_test_kb_relative_path = f"../knowledge_base/{DEFAULT_KB_NAME}"
     test_kb_full_path = (script_dir / default_test_kb_relative_path).resolve()
     print(f"テスト用ナレッジベースのパス: {test_kb_full_path}")
     if not test_kb_full_path.exists() or not test_kb_full_path.is_dir():

--- a/mm_kb_builder/README.md
+++ b/mm_kb_builder/README.md
@@ -15,6 +15,8 @@ Uploaded images and text are processed into embeddings so that the chatbot can s
    streamlit run app.py
    ```
 
-Processed data will be stored under `knowledge_base/multimodal_knowledge_base/`.
+Processed data will be stored under `knowledge_base/<kb_name>/` where
+`<kb_name>` defaults to the value of `DEFAULT_KB_NAME` defined in
+`config.py`.
 
-Sample metadata for a demo knowledge base is under `multimodal_data/`. The accompanying images are not tracked in git; copy any example images into `multimodal_data/multimodal_knowledge_base/images/` before running the app.
+Sample metadata for a demo knowledge base is under `multimodal_data/`. The accompanying images are not tracked in git; copy any example images into `multimodal_data/<kb_name>/images/` before running the app.

--- a/mm_kb_builder/app.py
+++ b/mm_kb_builder/app.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import streamlit as st
+from config import DEFAULT_KB_NAME
 from openai import OpenAI
 import json
 import base64
@@ -637,7 +638,7 @@ def save_unified_knowledge_item(
     try:
         search_chunk = create_comprehensive_search_chunk(analysis_result, user_additions)
         structured_metadata = create_structured_metadata(analysis_result, user_additions, filename)
-        kb_name = "multimodal_knowledge_base"
+        kb_name = DEFAULT_KB_NAME
         image_bytes = base64.b64decode(image_base64) if image_base64 else None
 
         full_metadata = {
@@ -1013,7 +1014,7 @@ with tab3:
     # ナレッジベース選択
     kb_name = st.selectbox(
         "ナレッジベース選択",
-        ["multimodal_knowledge_base"],  # 将来複数KB対応可能
+        [DEFAULT_KB_NAME],  # 将来複数KB対応可能
         index=0
     )
     

--- a/shared/kb_builder.py
+++ b/shared/kb_builder.py
@@ -6,6 +6,7 @@ from typing import Dict, Any
 
 from .file_processor import FileProcessor
 from .upload_utils import save_processed_data
+from config import DEFAULT_KB_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,7 @@ class KnowledgeBuilder:
         chunk_id = str(uuid.uuid4())
         metadata = {"filename": uploaded_file.name, "type": "text_chunk"}
         paths = save_processed_data(
-            "multimodal_knowledge_base",
+            DEFAULT_KB_NAME,
             chunk_id,
             chunk_text=text,
             embedding=embedding,
@@ -99,7 +100,7 @@ class KnowledgeBuilder:
             original_filename=uploaded_file.name,
             original_bytes=uploaded_file.getvalue(),
         )
-        self.refresh_search_engine("multimodal_knowledge_base")
+        self.refresh_search_engine(DEFAULT_KB_NAME)
         return {"id": chunk_id, **paths}
 
 

--- a/tests/test_unified_app.py
+++ b/tests/test_unified_app.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from config import DEFAULT_KB_NAME
 
 def test_sidebar_has_faq_button():
     text = Path('unified_app.py').read_text(encoding='utf-8')
@@ -17,5 +18,5 @@ def test_sidebar_has_faq_button():
 def test_manual_refresh_call_present():
     text = Path('unified_app.py').read_text(encoding='utf-8')
     import re
-    pattern = r'if st\.button\("検索インデックス更新"\).*refresh_search_engine\("default_kb"\)'
+    pattern = r'if st\.button\("検索インデックス更新"\).*refresh_search_engine\(DEFAULT_KB_NAME\)'
     assert re.search(pattern, text, re.DOTALL)

--- a/unified_app.py
+++ b/unified_app.py
@@ -7,6 +7,7 @@ from knowledge_gpt_app.app import (
     get_openai_client,
     refresh_search_engine,
 )
+from config import DEFAULT_KB_NAME
 from knowledge_gpt_app.gpt_handler import generate_gpt_response
 from ui_modules.thumbnail_editor import display_thumbnail_grid
 from ui_modules.theme import apply_intel_theme
@@ -113,7 +114,7 @@ if mode == "Upload":
                                 15,
                                 "C",
                                 "auto",
-                                "default_kb",
+                                DEFAULT_KB_NAME,
                                 client,
                                 original_filename=file.name,
                                 original_bytes=file.getvalue(),
@@ -121,16 +122,16 @@ if mode == "Upload":
                             )
 
             if process_mode == "まとめて処理" and index_mode == "自動(処理後)":
-                refresh_search_engine("default_kb")
+                refresh_search_engine(DEFAULT_KB_NAME)
 
             st.toast("アップロード完了")
 
         if index_mode == "手動":
             if st.button("検索インデックス更新"):
-                refresh_search_engine("default_kb")
+                refresh_search_engine(DEFAULT_KB_NAME)
 
     st.divider()
-    display_thumbnail_grid("default_kb")
+    display_thumbnail_grid(DEFAULT_KB_NAME)
 elif mode == "Chat":
     st.info("Chat mode is under construction.")
 elif mode == "FAQ":


### PR DESCRIPTION
## Summary
- add `DEFAULT_KB_NAME` setting in `config.py`
- use the constant across the unified app and builder modules
- update tests to reference `DEFAULT_KB_NAME`
- document the default knowledge base setting in the README
- revert changes to the legacy builder app to avoid patching a file with a non-ASCII name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f3e002ed0833381582ab1c7fab235