### PR TITLE
Fix thumbnail text size

### DIFF
--- a/ui_modules/theme.py
+++ b/ui_modules/theme.py
@@ -329,6 +329,7 @@ def apply_intel_theme(st):
         padding: 16px;
         margin-bottom: 16px;
         box-shadow: 0 1px 2px 0 rgba(60,64,67,.3);
+        font-size: 10pt;
     }
 
     /* Search input styling */


### PR DESCRIPTION
## Summary
- ensure document thumbnail cards use 10pt text
- revert global button font-size change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f74c42b288333a73dfda85fab56c5