### PR TITLE
Add error handling for GPT calls

### DIFF
--- a/tests/test_unified_app.py
+++ b/tests/test_unified_app.py
@@ -20,3 +20,30 @@ def test_manual_refresh_call_present():
     import re
     pattern = r'if st\.button\("検索インデックス更新"\).*refresh_search_engine\(DEFAULT_KB_NAME\)'
     assert re.search(pattern, text, re.DOTALL)
+
+
+def test_safe_generate_handles_error(monkeypatch):
+    import types
+    pytest = __import__('pytest')
+    pytest.importorskip('streamlit')
+
+    import streamlit as st
+    monkeypatch.setattr(st, 'error', lambda msg: monkeypatch.setattr(st, '_err', msg))
+
+    import importlib
+    monkeypatch.setattr('ui_modules.theme.apply_intel_theme', lambda *a, **k: None)
+    monkeypatch.setattr(st, 'set_page_config', lambda *a, **k: None)
+    monkeypatch.setattr(st, 'title', lambda *a, **k: None)
+    sidebar = types.SimpleNamespace(radio=lambda *a, **k: 'FAQ')
+    monkeypatch.setattr(st, 'sidebar', sidebar)
+    monkeypatch.setattr(st, 'info', lambda *a, **k: None)
+
+    mod = importlib.reload(__import__('unified_app'))
+
+    def boom(*a, **k):
+        raise RuntimeError('fail')
+
+    monkeypatch.setattr(mod, 'generate_gpt_response', boom)
+    result = mod.safe_generate_gpt_response('prompt', conversation_history=[], persona='default', temperature=0.1, response_length='簡潔', client=None)
+    assert result is None
+    assert getattr(st, '_err', None)


### PR DESCRIPTION
## Summary
- handle errors when generating GPT summaries in `unified_app.py`
- expose helper `safe_generate_gpt_response`
- add regression test covering the error path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7dfba4c48333ba9150b787f95d21