### PR TITLE
Clarify thumbnail editor ID handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ pytest -q
 ```
 
 See [ui_design_plan.md](ui_design_plan.md) and [docs/integration_plan.md](docs/integration_plan.md) for detailed design notes.
+
+## Developer Notes
+
+Item IDs used by the thumbnail editor correspond to the metadata filename
+without the `.json` extension. Upload helpers may prefix these filenames, so a
+thumbnail ID can look like `metadata_1`. When editing metadata manually, use the
+same ID shown in the grid.

--- a/ui_modules/thumbnail_editor.py
+++ b/ui_modules/thumbnail_editor.py
@@ -8,7 +8,12 @@ from shared.upload_utils import BASE_KNOWLEDGE_DIR, save_user_metadata
 
 
 def _load_items(kb_name: str) -> List[Dict[str, Any]]:
-    """Load stored items for the given knowledge base."""
+    """Load stored items for the given knowledge base.
+
+    The returned ``id`` for each item matches the metadata filename without the
+    ``.json`` extension. Some upload helpers prefix this filename (e.g.,
+    ``metadata_1``), so the ID may include that prefix.
+    """
     items = []
     meta_dir = BASE_KNOWLEDGE_DIR / kb_name / "metadata"
     if not meta_dir.exists():


### PR DESCRIPTION
## Summary
- describe how item IDs map to metadata filenames
- document ID prefix in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7f10702c833392cd4cdde749730e