### PR TITLE
Improve document search cards

### DIFF
--- a/generate_faq.py
+++ b/generate_faq.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from uuid import uuid4
 
 from shared.upload_utils import BASE_KNOWLEDGE_DIR, save_processed_data
-from mm_kb_builder.app import get_embedding
 
 try:
     from openai import OpenAI
@@ -58,7 +57,11 @@ def generate_faqs_from_chunks(kb_name: str, max_tokens: int = 1000, num_pairs: i
                 continue
             faq_id = f"faq_{uuid4().hex}"
             combined = f"Q: {q}\nA: {a}"
-            embedding = get_embedding(combined, client)
+            try:
+                from mm_kb_builder.app import get_embedding as _get_embedding
+            except Exception:
+                raise RuntimeError("Embedding function unavailable")
+            embedding = _get_embedding(combined, client)
             save_processed_data(
                 kb_name,
                 faq_id,

--- a/knowledge_gpt_app/app.py
+++ b/knowledge_gpt_app/app.py
@@ -60,6 +60,17 @@ from shared.upload_utils import (
 from generate_faq import generate_faqs_from_chunks
 from ui_modules.theme import apply_intel_theme
 
+# ロギング設定を最初に行う
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler("rag_tool.log", encoding='utf-8'),
+        logging.StreamHandler(),
+    ],
+)
+logger = logging.getLogger("rag_tool")
+
 # スクリプトディレクトリの解決
 current_dir = Path(__file__).resolve().parent
 
@@ -116,17 +127,6 @@ try:
 except Exception as e:
     logger.error(f"自作モジュールのインポートに失敗しました: {e}")
     traceback.print_exc()
-
-# ロギング設定
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler("rag_tool.log", encoding='utf-8'),
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('rag_tool')
 
 # OpenAIクライアントを取得する関数 (app.py内で共通して使用)
 @st.cache_resource
@@ -299,7 +299,8 @@ st.title("RAGシステム統合ツール")
 
 # アプリケーションモード選択
 mode_options = ["ナレッジ検索", "ナレッジ構築", "FAQ作成", "chatGPT"]
-app_mode_index = mode_options.index(st.session_state['app_mode']) if st.session_state['app_mode'] in mode_options else 0
+current_mode = st.session_state.get('app_mode', 'ナレッジ検索')
+app_mode_index = mode_options.index(current_mode) if current_mode in mode_options else 0
 app_mode = st.sidebar.radio(
     "モード選択",
     mode_options,

--- a/unified_app.py
+++ b/unified_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import streamlit as st
 from knowledge_gpt_app.app import (
     list_knowledge_bases,
@@ -64,9 +65,19 @@ def render_document_card(doc):
     text = doc.get("text", "")
     excerpt = text[:100]
     st.markdown(
-        f"<div class='doc-card'><strong>{filename}</strong><p>{excerpt}</p></div>",
+        f"<div class='doc-card'><strong>{filename}</strong><p>{excerpt}</p>",
         unsafe_allow_html=True,
     )
+    file_path = doc.get("metadata", {}).get("paths", {}).get("original_file_path")
+    if file_path and Path(file_path).exists():
+        with open(file_path, "rb") as f:
+            st.download_button(
+                "📄 ダウンロード",
+                f.read(),
+                file_name=Path(file_path).name,
+                key=f"download_{file_path}",
+            )
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 if mode == "Search" and st.session_state.get("search_executed"):


### PR DESCRIPTION
## Summary
- add download links for search result cards in `unified_app.py`
- avoid circular imports in `generate_faq.py`
- initialize logging before NLTK setup and guard session state in `knowledge_gpt_app/app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: streamlit / assertion errors)*


------
https://chatgpt.com/codex/tasks/task_e_685f9a8a10b483338f5ff3ad6e5dc9cf