### PR TITLE
Enhance manual index refresh UX

### DIFF
--- a/unified_app.py
+++ b/unified_app.py
@@ -151,7 +151,9 @@ if mode == "Upload":
 
         if index_mode == "手動":
             if st.button("検索インデックス更新"):
-                refresh_search_engine(DEFAULT_KB_NAME)
+                with st.spinner("検索エンジン更新中..."):
+                    refresh_search_engine(DEFAULT_KB_NAME)
+                st.toast("検索インデックスを更新しました")
 
     st.divider()
     display_thumbnail_grid(DEFAULT_KB_NAME)


### PR DESCRIPTION
## Summary
- show progress spinner and toast when refreshing index manually in the upload screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fbe390bc48333bec54b505a4e4968